### PR TITLE
Make Timeout::Error#exception with multiple arguments not ignore arguments

### DIFF
--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -32,9 +32,8 @@ module Timeout
     def self.catch(*args)
       exc = new(*args)
       exc.instance_variable_set(:@thread, Thread.current)
-      catch_value = Object.new
-      exc.instance_variable_set(:@catch_value, catch_value)
-      ::Kernel.catch(catch_value) {yield exc}
+      exc.instance_variable_set(:@catch_value, exc)
+      ::Kernel.catch(exc) {yield exc}
     end
 
     def exception(*)

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -85,7 +85,7 @@ module Timeout
 
     message ||= "execution expired".freeze
 
-    if (scheduler = Fiber.current_scheduler)&.respond_to?(:timeout_after)
+    if Fiber.respond_to?(:current_scheduler) && (scheduler = Fiber.current_scheduler)&.respond_to?(:timeout_after)
       return scheduler.timeout_after(sec, klass || Error, message, &block)
     end
 

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -80,6 +80,14 @@ class TestTimeout < Test::Unit::TestCase
     end
   end
 
+  def test_raise_with_message
+    bug17812 = '[ruby-core:103502] [Bug #17812]: Timeout::Error doesn\'t let two-argument raise() set a new message'
+    exc = Timeout::Error.new('foo')
+    assert_raise_with_message(Timeout::Error, 'bar', bug17812) do
+      raise exc, 'bar'
+    end
+  end
+
   def test_enumerator_next
     bug9380 = '[ruby-dev:47872] [Bug #9380]: timeout in Enumerator#next'
     e = (o=Object.new).to_enum


### PR DESCRIPTION
This makes:

  raise(Timeout::Error.new("hello"), "world")

raise a TimeoutError instance with "world" as the message instead
of "hello", for consistency with other Ruby exception classes.

This required some internal changes to keep the tests passing.

Fixes [Bug #17812]