### PR TITLE
test that yield is given number of seconds

### DIFF
--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -10,6 +10,10 @@ class TestTimeout < Test::Unit::TestCase
     end
   end
 
+  def test_yield_param
+    assert_equal [5, :ok], Timeout.timeout(5){|s| [s, :ok] }
+  end
+
   def test_queue
     q = Thread::Queue.new
     assert_raise(Timeout::Error, "[ruby-dev:32935]") {


### PR DESCRIPTION
Nothing currently covers this behavior