### PR TITLE
Add and test JRuby implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ '3.0', 2.7, 2.6, 2.5, 2.4, head ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5, 2.4, head, jruby-head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -131,3 +131,9 @@ module Timeout
 
   module_function :timeout
 end
+
+# Load impl-specific logic on top of base implementation
+case RUBY_ENGINE
+when 'jruby'
+  require 'timeout/jruby'
+end

--- a/lib/timeout/jruby.rb
+++ b/lib/timeout/jruby.rb
@@ -1,24 +1,6 @@
 require 'jruby'
 
 module Timeout
-  # A module to hold the executor for timeout operations
-  module JRuby
-    java_import java.util.concurrent.ScheduledThreadPoolExecutor
-    java_import java.lang.Runtime
-    java_import org.jruby.threading.DaemonThreadFactory
-    java_import java.util.concurrent.atomic.AtomicBoolean
-    java_import org.jruby.RubyTime
-    java_import java.util.concurrent.TimeUnit
-    java_import java.util.concurrent.ExecutionException
-    java_import java.lang.InterruptedException
-
-    EXECUTOR = ScheduledThreadPoolExecutor.new(
-      Runtime.runtime.available_processors,
-      DaemonThreadFactory.new)
-    EXECUTOR.remove_on_cancel_policy = true
-  end
-
-  # An efficient timeout implementation based on the JDK's ScheduledThreadPoolExecutor
   module_function def timeout(sec, klass = nil, message = nil, &block)
     #:yield: +sec+
     return yield(sec) if sec == nil or sec.zero?
@@ -29,38 +11,83 @@ module Timeout
       return scheduler.timeout_after(sec, klass || Error, message, &block)
     end
 
-    current_thread = Thread.current
-    latch = JRuby::AtomicBoolean.new(false);
+    JRubyTimeout.timeout(sec, klass, message, &block)
+  end
 
-    id = klass.nil? ? Object.new : nil;
+  # An efficient timeout implementation based on the JDK's ScheduledThreadPoolExecutor
+  class JRubyTimeout
+    java_import java.util.concurrent.ScheduledThreadPoolExecutor
+    java_import java.lang.Runtime
+    java_import org.jruby.threading.DaemonThreadFactory
+    java_import java.util.concurrent.atomic.AtomicBoolean
+    java_import org.jruby.RubyTime
+    java_import java.util.concurrent.ExecutionException
+    java_import java.lang.InterruptedException
+    java_import java.lang.Runnable
 
-    sec_float = JRuby::RubyTime.convert_time_interval ::JRuby.runtime.current_context, sec
+    MICROSECONDS = java.util.concurrent.TimeUnit::MICROSECONDS
 
-    timeout_runnable = -> {
+    # Executor for timeout jobs
+    EXECUTOR = ScheduledThreadPoolExecutor.new(
+      Runtime.runtime.available_processors,
+      DaemonThreadFactory.new)
+    EXECUTOR.remove_on_cancel_policy = true
+
+    # Current JRuby runtime
+    RUNTIME = JRuby.runtime
+
+    include Runnable
+
+    def self.timeout(seconds, exception_class, message)
+      timeout_job = new(exception_class, message)
+      timeout_job.start(seconds)
+      begin
+        yield seconds
+      ensure
+        timeout_job.finish
+      end
+    end
+
+    def initialize(exception_class, message)
+      @exception_class = exception_class
+      @message = message
+
+      @id = exception_class.nil? ? Object.new : nil
+      @latch = AtomicBoolean.new
+      @current_thread = Thread.current
+    end
+
+    def run
       # check latch to see if we have been canceled
-      if latch.compare_and_set(false, true)
-        if klass.nil?
-          timeout_exception = Timeout::Error.new(message)
-          timeout_exception.instance_variable_set(:@exception_id, id)
-          current_thread.raise(timeout_exception)
+      if @latch.compare_and_set(false, true)
+        exception_class = @exception_class
+        if exception_class.nil?
+          timeout_exception = Timeout::Error.new(@message)
+          timeout_exception.instance_variable_set(:@exception_id, @id)
+          @current_thread.raise(timeout_exception)
         else
-          current_thread.raise(klass, message);
+          @current_thread.raise(exception_class, @message);
         end
       end
-    }
+    end
 
-    timeout_future = JRuby::EXECUTOR.schedule(timeout_runnable, sec_float * 1_000_000, JRuby::TimeUnit::MICROSECONDS)
-    begin
-      yield sec
-    ensure
-      if latch.compare_and_set(false, true) && timeout_future.cancel(false)
+    def start(seconds)
+      sec_float = RubyTime.convert_time_interval RUNTIME.current_context, seconds
+      usec_float = sec_float * 1_000_000
+
+      @timeout_future = EXECUTOR.schedule(self, usec_float, MICROSECONDS)
+    end
+
+    def finish
+      timeout_future = @timeout_future
+      if @latch.compare_and_set(false, true) && timeout_future.cancel(false)
         # ok, exception will not fire (also cancel caused task to be removed)
       else
         # future is not cancellable, wait for it to run and ignore results
         begin
           timeout_future.get
-        rescue JRuby::ExecutionException
-        rescue JRuby::InterruptedException
+        rescue ExecutionException
+        rescue InterruptedException
         end
       end
     end

--- a/lib/timeout/jruby.rb
+++ b/lib/timeout/jruby.rb
@@ -1,0 +1,68 @@
+require 'jruby'
+
+module Timeout
+  # A module to hold the executor for timeout operations
+  module JRuby
+    java_import java.util.concurrent.ScheduledThreadPoolExecutor
+    java_import java.lang.Runtime
+    java_import org.jruby.threading.DaemonThreadFactory
+    java_import java.util.concurrent.atomic.AtomicBoolean
+    java_import org.jruby.RubyTime
+    java_import java.util.concurrent.TimeUnit
+    java_import java.util.concurrent.ExecutionException
+    java_import java.lang.InterruptedException
+
+    EXECUTOR = ScheduledThreadPoolExecutor.new(
+      Runtime.runtime.available_processors,
+      DaemonThreadFactory.new)
+    EXECUTOR.remove_on_cancel_policy = true
+  end
+
+  # An efficient timeout implementation based on the JDK's ScheduledThreadPoolExecutor
+  module_function def timeout(sec, klass = nil, message = nil, &block)
+    #:yield: +sec+
+    return yield(sec) if sec == nil or sec.zero?
+
+    message ||= "execution expired".freeze
+
+    if Fiber.respond_to?(:current_scheduler) && (scheduler = Fiber.current_scheduler)&.respond_to?(:timeout_after)
+      return scheduler.timeout_after(sec, klass || Error, message, &block)
+    end
+
+    current_thread = Thread.current
+    latch = JRuby::AtomicBoolean.new(false);
+
+    id = klass.nil? ? Object.new : nil;
+
+    sec_float = JRuby::RubyTime.convert_time_interval ::JRuby.runtime.current_context, sec
+
+    timeout_runnable = -> {
+      # check latch to see if we have been canceled
+      if latch.compare_and_set(false, true)
+        if klass.nil?
+          timeout_exception = Timeout::Error.new(message)
+          timeout_exception.instance_variable_set(:@exception_id, id)
+          current_thread.raise(timeout_exception)
+        else
+          current_thread.raise(klass, message);
+        end
+      end
+    }
+
+    timeout_future = JRuby::EXECUTOR.schedule(timeout_runnable, sec_float * 1_000_000, JRuby::TimeUnit::MICROSECONDS)
+    begin
+      yield sec
+    ensure
+      if latch.compare_and_set(false, true) && timeout_future.cancel(false)
+        # ok, exception will not fire (also cancel caused task to be removed)
+      else
+        # future is not cancellable, wait for it to run and ignore results
+        begin
+          timeout_future.get
+        rescue JRuby::ExecutionException
+        rescue JRuby::InterruptedException
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR incorporates a pure-Ruby port of JRuby's native `timeout` logic into this library.

The existing implementation spins up a new native thread per timeout request, which is inefficient for several reasons:

* Starting a new native thread has a large nontrivial cost.
* Setting up Ruby thread state associated with that native thread also has a large cost.
* Waiting for the timeout thread to terminate is slow and expensive and delays processing of what would otherwise have run quickly.
* Operations that do not time out still incur all these costs, and such operations generally make up a huge majority of timeout requests.

This last point is perhaps the most worrisome: nearly all operations that pass through this code will never time out and do not need the timeout thread, but it is still created and joined every time.

Instead, we use the JDK `ScheduledThreadPoolExecutor`, which spins up a single thread and schedules timeout requests into it. No more than one thread will ever be started, and operations that do not time out incur only the cost of enqueueing the timeout request.

Performance is naturally much faster than spinning up a thread each time (see benchmark and performance below).

This PR starts out as a draft for a few reasons:

* No work has been done to optimize this naive port of our Java implementation. It is functionally nearly the same, but there's additional Ruby execution overhead that could be improved.
* The base `timeout` library could be improved and used by all implemenations by using logic similar to JDK's `ScheduledThreadPoolExecutor`. This simplest way to do this would be to use the version of `timeout` that @evanphx wrote for Rubinius (now incorporated into TruffleRuby): https://github.com/oracle/truffleruby/blob/master/lib/truffle/timeout.rb
* This logic uses JRuby internal methods `JRuby.runtime` (which requires us to `require 'jruby'`) and `org.jruby.RubyTime#convert_time_interval`

This implementation currently passes all but one test, but I am unsure how important this test is or what exactly the expected behavior is supposed to be (`test_skip_rescue`):

```
Failure: test_skip_rescue(TestTimeout):
  [Bug #8730].
  Timeout::Error expected but nothing was raised.
/Users/headius/projects/timeout/test/lib/core_assertions.rb:411:in `assert_raise'
/Users/headius/projects/timeout/test/lib/core_assertions.rb:449:in `block in assert_raise_with_message'
/Users/headius/projects/timeout/test/lib/envutil.rb:254:in `with_default_internal'
/Users/headius/projects/timeout/test/lib/core_assertions.rb:448:in `assert_raise_with_message'
/Users/headius/projects/timeout/test/test_timeout.rb:41:in `test_skip_rescue'
     38:   def test_skip_rescue
     39:     bug8730 = '[Bug #8730]'
     40:     e = nil
  => 41:     assert_raise_with_message(Timeout::Error, /execution expired/, bug8730) do
     42:       Timeout.timeout 0.01 do
     43:         begin
     44:           sleep 3
```

Benchmark and results are below (on JRuby master/9.4):

```ruby
require 'timeout'
require 'benchmark'

20.times {
  puts Benchmark.measure {
    10000.times { Timeout.timeout(1) { } }
  }
}
```

Before:
```
  5.450000   1.300000   6.750000 (  2.802191)
  2.770000   1.010000   3.780000 (  1.923030)
  2.140000   0.880000   3.020000 (  1.527967)
  1.350000   0.880000   2.230000 (  1.611158)
  1.130000   0.790000   1.920000 (  1.380240)
  1.170000   0.780000   1.950000 (  1.382086)
  1.170000   0.800000   1.970000 (  1.413524)
  1.160000   0.800000   1.960000 (  1.442907)
  1.180000   0.810000   1.990000 (  1.554301)
  1.230000   0.870000   2.100000 (  1.582411)
  1.290000   0.890000   2.180000 (  1.632331)
  1.120000   0.760000   1.880000 (  1.346911)
  1.140000   0.770000   1.910000 (  1.359328)
  1.150000   0.780000   1.930000 (  1.361715)
  1.120000   0.770000   1.890000 (  1.364992)
  1.150000   0.780000   1.930000 (  1.373353)
  1.130000   0.780000   1.910000 (  1.379838)
  1.140000   0.780000   1.920000 (  1.370240)
  1.120000   0.760000   1.880000 (  1.350525)
  1.120000   0.770000   1.890000 (  1.356122)
```

After:
```
  1.920000   0.160000   2.080000 (  0.790326)
  0.920000   0.110000   1.030000 (  0.475900)
  0.910000   0.080000   0.990000 (  0.391800)
  0.880000   0.090000   0.970000 (  0.427838)
  0.700000   0.070000   0.770000 (  0.351840)
  0.770000   0.110000   0.880000 (  0.348264)
  0.500000   0.070000   0.570000 (  0.396809)
  0.400000   0.060000   0.460000 (  0.204967)
  0.640000   0.070000   0.710000 (  0.254044)
  0.370000   0.060000   0.430000 (  0.176363)
  0.340000   0.050000   0.390000 (  0.173846)
  0.560000   0.080000   0.640000 (  0.231835)
  0.220000   0.060000   0.280000 (  0.171603)
  0.150000   0.040000   0.190000 (  0.142593)
  0.170000   0.050000   0.220000 (  0.162614)
  0.380000   0.050000   0.430000 (  0.200650)
  0.150000   0.040000   0.190000 (  0.137969)
  0.150000   0.040000   0.190000 (  0.139971)
  0.390000   0.060000   0.450000 (  0.205751)
  0.150000   0.050000   0.200000 (  0.137077)
```

And using our Java implementation, as an example of the lost performance from this naive port (which is about 4x slower):
```
  0.360000   0.050000   0.410000 (  0.107624)
  0.180000   0.050000   0.230000 (  0.082377)
  0.190000   0.040000   0.230000 (  0.073103)
  0.220000   0.050000   0.270000 (  0.081130)
  0.100000   0.020000   0.120000 (  0.037514)
  0.130000   0.030000   0.160000 (  0.052505)
  0.110000   0.030000   0.140000 (  0.041658)
  0.010000   0.010000   0.020000 (  0.021479)
  0.020000   0.020000   0.040000 (  0.024502)
  0.020000   0.020000   0.040000 (  0.022926)
  0.020000   0.010000   0.030000 (  0.023047)
  0.020000   0.020000   0.040000 (  0.020899)
  0.100000   0.030000   0.130000 (  0.057042)
  0.040000   0.030000   0.070000 (  0.047345)
  0.060000   0.030000   0.090000 (  0.039323)
  0.060000   0.030000   0.090000 (  0.039203)
  0.040000   0.020000   0.060000 (  0.029292)
  0.030000   0.020000   0.050000 (  0.040910)
  0.030000   0.030000   0.060000 (  0.044159)
  0.030000   0.030000   0.060000 (  0.044382)
```

Fixes #11.