### PR TITLE
gemspec: Drop unused directives "executables"

### DIFF
--- a/timeout.gemspec
+++ b/timeout.gemspec
@@ -26,7 +26,5 @@ Gem::Specification.new do |spec|
       (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features|rakelib)/|\.(?:git|travis|circleci)|appveyor|Rakefile)})
     end
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
This gem exposes no executables.