### PR TITLE
Explicit add the timeout thread to default ThreadGroup

### DIFF
--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -120,6 +120,7 @@ module Timeout
         requests.reject!(&:done?)
       end
     end
+    ThreadGroup::Default.add(watcher)
     watcher.name = "Timeout stdlib thread"
     watcher.thread_variable_set(:"\0__detached_thread__", true)
     watcher

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -159,4 +159,17 @@ class TestTimeout < Test::Unit::TestCase
     assert_equal 'timeout', r.read
     r.close
   end
+
+  def test_threadgroup
+    assert_separately(%w[-rtimeout], <<-'end;')
+      tg = ThreadGroup.new
+      thr = Thread.new do
+        tg.add(Thread.current)
+        Timeout.timeout(10){}
+      end
+      thr.join
+      assert_equal [].to_s, tg.list.to_s
+    end;
+  end
+
 end


### PR DESCRIPTION
Otherwise the timeout thread would be added to the `ThreadGroup` of the thread that makes the first call to `Timeout.timeout` .

Fixes bug 19020: https://bugs.ruby-lang.org/issues/19020

Do you wish a test for the `ThreadGroup` or is it an implementation detail?
