### PR TITLE
Don't move the timer_thread when it's enclosed #24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', '3.1', '3.0', '2.7', head, jruby, truffleruby-head ]
+        ruby: [ '3.2', '3.1', '3.0', '2.7', head, jruby, truffleruby, truffleruby-head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -120,7 +120,7 @@ module Timeout
         requests.reject!(&:done?)
       end
     end
-    ThreadGroup::Default.add(watcher)
+    ThreadGroup::Default.add(watcher) unless watcher.group.enclosed?
     watcher.name = "Timeout stdlib thread"
     watcher.thread_variable_set(:"\0__detached_thread__", true)
     watcher

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -172,4 +172,23 @@ class TestTimeout < Test::Unit::TestCase
     end;
   end
 
+  def test_handling_enclosed_threadgroup
+    # The problem "add: can't move from the enclosed thread group" #24,
+    # happens when the timeout_thread is created in an enclosed ThreadGroup.
+    assert_separately(%w[-rtimeout], <<-'end;')
+      t1 = Thread.new {
+        Thread.stop
+        assert_block do
+          Timeout.timeout(0.1) {}
+          true
+        end
+      }
+      sleep 0.1 while t1.status != 'sleep'
+      group = ThreadGroup.new
+      group.add(t1)
+      group.enclose
+      t1.run
+      t1.join
+    end;
+  end
 end


### PR DESCRIPTION
Don't move the timer_thread to ThreadGroup::Default, when it's created in an enclosed ThreadGroup.
Prevents the exception: "add" can't move from the enclosed thread group"
Fixes #24.