### PR TITLE
require ruby version in gemspec

### DIFF
--- a/timeout.gemspec
+++ b/timeout.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 
+  spec.required_ruby_version = '>= 2.5.0'
+
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
       (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features|rakelib)/|\.(?:git|travis|circleci)|appveyor|Rakefile)})


### PR DESCRIPTION
I believe because of the reference to the Fiber class, the minimum ruby version is 2.5

The suite only starts at 3.0, so maybe that's the more official/implied required version to use?