### PR TITLE
Require Ruby >= 2.6 for the timeout gem

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby-truffleruby
+      min_version: 2.6
 
   test:
     needs: ruby-versions

--- a/timeout.gemspec
+++ b/timeout.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
* The test suite fails on 2.5.
* See https://github.com/ruby/timeout/pull/35