### PR TITLE
tests for blank seconds

### DIFF
--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -19,6 +19,18 @@ class TestTimeout < Test::Unit::TestCase
     end
   end
 
+  def test_allows_zero_seconds
+    assert_nothing_raised do
+      assert_equal :ok, Timeout.timeout(0){:ok}
+    end
+  end
+
+  def test_allows_nil_seconds
+    assert_nothing_raised do
+      assert_equal :ok, Timeout.timeout(nil){:ok}
+    end
+  end
+
   def test_included
     c = Class.new do
       include Timeout


### PR DESCRIPTION
without these tests, if `return yield(sec) if sec == nil or sec.zero?` is commented out, no tests fail

with these tests, if that line is commented out:
* `test_allows_nil_seconds` does fail
* `test_allows_zero_seconds` does _not_ fail

i couldn't think of a way to test "blank seconds bypasses all other logic" (and don't have an opinion if that's important)