### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/timeout

### DIFF
--- a/timeout.gemspec
+++ b/timeout.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = spec.homepage + "/releases"
 
   spec.required_ruby_version = '>= 2.6.0'
 


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/timeout which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/