### PR TITLE
Global #timeout was removed 5 years ago

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 Timeout provides a way to auto-terminate a potentially long-running
 operation if it hasn't finished in a fixed amount of time.
 
-Previous versions didn't use a module for namespacing, however
-#timeout is provided for backwards compatibility.  You
-should prefer Timeout.timeout instead.
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -27,7 +23,7 @@ Or install it yourself as:
 
 ```ruby
 require 'timeout'
-status = Timeout::timeout(5) {
+status = Timeout.timeout(5) {
   # Something that should be interrupted if it takes more than 5 seconds...
 }
 ```


### PR DESCRIPTION
* Also update Timeout::timeout to the more common format of Timeout.timeout

I spent like 45 minutes trying to figure out why the top-level `timeout` didn't work, and then spent more time trying to figure out how it possibly could work based on the current code 😅 . Turns out it was removed years ago - so this updates the docs to reflect that.