### PR TITLE
added the check for negative sec

### DIFF
--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -164,7 +164,7 @@ module Timeout
   # Timeout</tt> into your classes so they have a #timeout method, as well as
   # a module method, so you can call it directly as Timeout.timeout().
   def timeout(sec, klass = nil, message = nil, &block)   #:yield: +sec+
-    raise ArgumentError, "Timeout sec must be a positive number" unless sec.is_a?(Numeric) && sec >= 0
+    raise ArgumentError, "Timeout sec must be a positive number" if sec.is_a?(Numeric) && sec < 0
     return yield(sec) if sec == nil or sec.zero?
 
     message ||= "execution expired"

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -141,9 +141,10 @@ module Timeout
   # Perform an operation in a block, raising an error if it takes longer than
   # +sec+ seconds to complete.
   #
-  # +sec+:: Number of seconds to wait for the block to terminate. Any number
-  #         may be used, including Floats to specify fractional seconds. A
+  # +sec+:: Number of seconds to wait for the block to terminate. Any non-negative number
+  #         or nil may be used, including Floats to specify fractional seconds. A
   #         value of 0 or +nil+ will execute the block without any timeout.
+  #         Any negative value will raise the ArgumentError
   # +klass+:: Exception Class to raise if the block fails to terminate
   #           in +sec+ seconds.  Omitting will use the default, Timeout::Error
   # +message+:: Error message to raise with Exception Class.
@@ -164,8 +165,8 @@ module Timeout
   # Timeout</tt> into your classes so they have a #timeout method, as well as
   # a module method, so you can call it directly as Timeout.timeout().
   def timeout(sec, klass = nil, message = nil, &block)   #:yield: +sec+
-    raise ArgumentError, "Timeout sec must be a positive number" unless sec.is_a?(Numeric) && sec >= 0
-    return yield(sec) if sec.zero?
+    raise ArgumentError, "Timeout sec must be a non-negative number" if sec && !(sec.is_a?(Numeric) && sec >= 0)
+    return yield(sec) if sec == nil or sec.zero?
 
     message ||= "execution expired"
 

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -164,8 +164,8 @@ module Timeout
   # Timeout</tt> into your classes so they have a #timeout method, as well as
   # a module method, so you can call it directly as Timeout.timeout().
   def timeout(sec, klass = nil, message = nil, &block)   #:yield: +sec+
-    raise ArgumentError, "Timeout sec must be a positive number" if sec.is_a?(Numeric) && sec < 0
-    return yield(sec) if sec == nil or sec.zero?
+    raise ArgumentError, "Timeout sec must be a positive number" unless sec.is_a?(Numeric) && sec >= 0
+    return yield(sec) if sec.zero?
 
     message ||= "execution expired"
 

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -164,6 +164,7 @@ module Timeout
   # Timeout</tt> into your classes so they have a #timeout method, as well as
   # a module method, so you can call it directly as Timeout.timeout().
   def timeout(sec, klass = nil, message = nil, &block)   #:yield: +sec+
+    raise ArgumentError, "Timeout sec must be a positive number" unless sec.is_a?(Numeric) && sec >= 0
     return yield(sec) if sec == nil or sec.zero?
 
     message ||= "execution expired"

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -144,7 +144,7 @@ module Timeout
   # +sec+:: Number of seconds to wait for the block to terminate. Any non-negative number
   #         or nil may be used, including Floats to specify fractional seconds. A
   #         value of 0 or +nil+ will execute the block without any timeout.
-  #         Any negative value will raise the ArgumentError
+  #         Any negative number will raise an ArgumentError.
   # +klass+:: Exception Class to raise if the block fails to terminate
   #           in +sec+ seconds.  Omitting will use the default, Timeout::Error
   # +message+:: Error message to raise with Exception Class.

--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -165,8 +165,8 @@ module Timeout
   # Timeout</tt> into your classes so they have a #timeout method, as well as
   # a module method, so you can call it directly as Timeout.timeout().
   def timeout(sec, klass = nil, message = nil, &block)   #:yield: +sec+
-    raise ArgumentError, "Timeout sec must be a non-negative number" if sec && !(sec.is_a?(Numeric) && sec >= 0)
     return yield(sec) if sec == nil or sec.zero?
+    raise ArgumentError, "Timeout sec must be a non-negative number" if 0 > sec
 
     message ||= "execution expired"
 

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 require 'test/unit'
-require 'timeout'
+require_relative '../lib/timeout'
 
 class TestTimeout < Test::Unit::TestCase
 
@@ -28,6 +28,12 @@ class TestTimeout < Test::Unit::TestCase
   def test_allows_nil_seconds
     assert_nothing_raised do
       assert_equal :ok, Timeout.timeout(nil){:ok}
+    end
+  end
+
+  def test_raise_for_neg_second
+    assert_raise(ArgumentError) do
+      Timeout.timeout(-1) { sleep(0.01) }
     end
   end
 

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -26,7 +26,7 @@ class TestTimeout < Test::Unit::TestCase
   end
 
   def test_allows_nil_seconds
-    assert_raise(ArgumentError) do
+    assert_nothing_raised do
       assert_equal :ok, Timeout.timeout(nil){:ok}
     end
   end

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -26,7 +26,7 @@ class TestTimeout < Test::Unit::TestCase
   end
 
   def test_allows_nil_seconds
-    assert_nothing_raised do
+    assert_raise(ArgumentError) do
       assert_equal :ok, Timeout.timeout(nil){:ok}
     end
   end
@@ -120,7 +120,7 @@ class TestTimeout < Test::Unit::TestCase
   def test_cannot_convert_into_time_interval
     bug3168 = '[ruby-dev:41010]'
     def (n = Object.new).zero?; false; end
-    assert_raise(TypeError, bug3168) {Timeout.timeout(n) { sleep 0.1 }}
+    assert_raise(ArgumentError, bug3168) {Timeout.timeout(n) { sleep 0.1 }}
   end
 
   def test_skip_rescue_standarderror

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 require 'test/unit'
-require_relative '../lib/timeout'
+require 'timeout'
 
 class TestTimeout < Test::Unit::TestCase
 


### PR DESCRIPTION
```ruby
 RUBY_VERSION
=> "3.2.3"
irb(main):006> require 'timeout'
=> true

# Case 1: Negative timeout with quick execution

irb(main):007* Timeout.timeout(-5) do
irb(main):008*   puts "This should not execute"
irb(main):009> end
This should not execute
=> nil

# Case 2: Negative timeout with sleep

irb(main):010* Timeout.timeout(-5) do
irb(main):011*   sleep(10)
irb(main):012> end
C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timeout-0.4.1/lib/timeout.rb:43:in `rescue in handle_timeout': execution expired (Timeout::Error)
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timeout-0.4.1/lib/timeout.rb:40:in `handle_timeout'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timeout-0.4.1/lib/timeout.rb:195:in `timeout'
        from (irb):10:in `<main>'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/irb-1.12.0/exe/irb:9:in `<top (required)>'
        from C:/Ruby32-x64/bin/irb:25:in `load'
        from C:/Ruby32-x64/bin/irb:25:in `<main>'
(irb):11:in `sleep': execution expired (Timeout::ExitException)
        from (irb):11:in `block in <top (required)>'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timeout-0.4.1/lib/timeout.rb:186:in `block in timeout'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timeout-0.4.1/lib/timeout.rb:41:in `handle_timeout'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timeout-0.4.1/lib/timeout.rb:195:in `timeout'
        from (irb):10:in `<main>'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/irb-1.12.0/exe/irb:9:in `<top (required)>'
        from C:/Ruby32-x64/bin/irb:25:in `load'
        from C:/Ruby32-x64/bin/irb:25:in `<main>'

 Timeout::VERSION
=> "0.4.1"


```

Potential issues with current behaviour:

- Inconsistency: The behaviour differs based on the block's content, which may not be immediately apparent
- Silent failure: The negative timeout is silently ignored, potentially masking logical errors in the calling code.
- Unexpected source of error: one might expect the timeout method to validate its input, rather than relying on methods called within the block to catch invalid time values.

I suggest this change for the consistent behaviour regardless of code-block as well as the clear indication of the source of the error