### PR TITLE
Gracefully handle a call to ensure_timeout_thread_created in a signal handler

### DIFF
--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -123,6 +123,9 @@ module Timeout
 
   def self.ensure_timeout_thread_created
     unless @timeout_thread and @timeout_thread.alive?
+      # If the Mutex is already owned we are in a signal handler.
+      # In that case, just return and let the main thread create the @timeout_thread.
+      return if TIMEOUT_THREAD_MUTEX.owned?
       TIMEOUT_THREAD_MUTEX.synchronize do
         unless @timeout_thread and @timeout_thread.alive?
           @timeout_thread = create_timeout_thread


### PR DESCRIPTION
* Fixes the issue described in https://github.com/ruby/timeout/issues/17#issuecomment-1461498517 for TruffleRuby and JRuby.
* CRuby is currently unable to use Timeout in a signal handler due to https://bugs.ruby-lang.org/issues/19473.